### PR TITLE
PHP requirement incompatible with Magento 2 PHP version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "emizentech/categorywidget",
     "description": "Emizentech Category List Widget",
     "require": {
-        "php": "~5.5.0|~5.6.0|~7.0.0"
+        "php": "~7.1.3||~7.2.0||~7.3.0"
     },
     "type": "magento2-module",
     "version": "1.0.0",


### PR DESCRIPTION
[InvalidArgumentException]                                                   
  Package emizentech/categorywidget at version  has a PHP requirement incompatible with your PHP version (7.3.17)